### PR TITLE
Fix iOS Zoom Issue on textarea Focus by Adjusting Font Size

### DIFF
--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -18,4 +18,8 @@
   .code-text {
     @apply text-sm font-mono text-neutral-300;
   }
+
+  .textarea {
+    @apply text-base;
+  }
 }


### PR DESCRIPTION
This PR resolves an issue where the `textarea` class would cause an unwanted zoom effect on iOS devices when focused. The zoom was triggered by the default font size of the <textarea>, which was 14px (`text-sm` in Tailwind/DaisyUI). iOS applies a zoom-in behavior for inputs and textareas with a font size smaller than 16px.

Before:

https://github.com/user-attachments/assets/0b52f628-99ba-4755-b60f-c586bbbb67ab


After:

https://github.com/user-attachments/assets/c2ec9b43-f86b-4d9f-88f3-99934cc00637


More info: https://css-tricks.com/16px-or-larger-text-prevents-ios-form-zoom/


