### PR TITLE
Add support for viewing website on another device over local network

### DIFF
--- a/package.json
+++ b/package.json
@@ -38,7 +38,7 @@
     "test:e2e:update-snapshot": "playwright test --update-snapshots",
     "test": "pnpm test:unit && pnpm test:e2e",
     "predev": "pnpm lint",
-    "dev": "next dev --turbopack",
+    "dev": "next dev --turbopack -H 0.0.0.0",
     "check:favicon": "realfavicon check 3000",
     "scan:secrets": "ggshield secret scan repo .",
     "start": "next start"


### PR DESCRIPTION
Added 0.0.0.0 to host argument on `npm run dev` so that you can view the website on another device in your local network, such as a mobile device, to enable better testing on real devices during development.