### PR TITLE
fix(pre-commit): added husky hook bypass for github actions bot

### DIFF
--- a/.changeset/bright-points-shout.md
+++ b/.changeset/bright-points-shout.md
@@ -1,0 +1,5 @@
+---
+"buckeye-gpt": patch
+---
+
+Fixed changeset error when creating versioning PR by allowing github-actions[bot] commit author to bypass pre-commit and commitizen husky hooks.

--- a/.github/workflows/code-quality.yaml
+++ b/.github/workflows/code-quality.yaml
@@ -1,18 +1,17 @@
-name: ChangeSet
+name: Biome CI
 
 on:
   push:
-    branches:
-      - main
-
-concurrency: ${{ github.workflow }}-${{ github.ref }}
+  pull_request:
+  workflow_dispatch:
+  schedule:
+    - cron: '0 7 * * 0'
 
 jobs:
-  release:
+  unit-test:
     runs-on: ubuntu-latest
     permissions:
       contents: read
-      pull-requests: write
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
@@ -33,8 +32,5 @@ jobs:
       - name: Install dependencies
         run: pnpm install --frozen-lockfile
 
-      - name: Create changeset release pull request
-        # Pinned to commit hash of release v1.4.9 on 10/14/24.
-        uses: changesets/action@c8bada60c408975afd1a20b3db81d6eee6789308
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      - name: Check import organization, formatting, and lint
+        run: pnpm lint

--- a/.github/workflows/e2e-test.yaml
+++ b/.github/workflows/e2e-test.yaml
@@ -1,4 +1,4 @@
-name: E2E Test
+name: Playwright
 
 on:
   push:
@@ -67,7 +67,7 @@ jobs:
           path: ${{ env.PLAYWRIGHT_DEPS_PATH }}
           key: ${{ runner.os }}-playwright-${{ steps.playwright-version.outputs.PLAYWRIGHT_VERSION }}
 
-      - name: Install Playwrigtht dependencies with cache
+      - name: Install Playwrigtht dependencies with cache on cache miss
         if: steps.playwright-cache.outputs.cache-hit != 'true'
         run: pnpm test:e2e:install
 

--- a/.github/workflows/unit-test.yaml
+++ b/.github/workflows/unit-test.yaml
@@ -1,4 +1,4 @@
-name: Unit Test
+name: Vitest
 
 on:
   push:
@@ -55,12 +55,6 @@ jobs:
 
       - name: Install dependencies
         run: pnpm install --frozen-lockfile
-
-      - name: CI lint
-        run: pnpm lint
-
-      - name: Test build
-        run: pnpm build
 
       - name: Unit test
         run: pnpm test:unit:coverage

--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -1,3 +1,10 @@
 #!/bin/bash
 
+# Skip pre-commit checks if commit author is GitHub Actions bot.
+if git config --get user.name | grep -q "github-actions[bot]"; then
+    echo "🤖 GitHub Actions bot detected, skipping verification."
+    exit 0
+fi
+
+# For all other commits: run pre-commit checks.
 pnpm verify

--- a/.husky/prepare-commit-msg
+++ b/.husky/prepare-commit-msg
@@ -1,8 +1,10 @@
 #!/bin/bash
 
-# Step 1. Allow terminal input for commitizen prompts.
-exec < /dev/tty
+# Skip commitizen if commit author is GitHub Actions bot.
+if git config --get user.name | grep -q "github-actions[bot]"; then
+    echo "🤖 GitHub Actions bot detected, skipping commitizen."
+    exit 0
+fi
 
-# Step 2. Run commitizen to format commit messages, 
-# fallback to skipping with success if it fails
-pnpm cz --hook || true
+# For all other commits: try commitizen with fallback.
+exec < /dev/tty && pnpm cz --hook || true


### PR DESCRIPTION
changeset github action requires privilage to make docs-only commits, need to give it bypass to all code checks

fix #107